### PR TITLE
Updates pages-branch to gh-pages

### DIFF
--- a/.cr.yaml
+++ b/.cr.yaml
@@ -1,6 +1,6 @@
 owner: unmango
 git-repo: charts
-pages-branch: main
+pages-branch: gh-pages
 pages-index-path: index.yaml
 generate-release-notes: true
 skip-existing: true


### PR DESCRIPTION
Changes default branch for GitHub Pages from 'main' to
'gh-pages' to align with GitHub hosting requirements or
organizational standards.
